### PR TITLE
[fix] RedisConfig 원격 빈 객체 줬다 뺐기

### DIFF
--- a/src/main/java/io/pp/arcade/global/config/RedisConfig.java
+++ b/src/main/java/io/pp/arcade/global/config/RedisConfig.java
@@ -59,9 +59,4 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    @Bean
-    public static ConfigureRedisAction redisConfigureAction(){
-        return ConfigureRedisAction.NO_OP;
-    }
-
 }


### PR DESCRIPTION
- [x] 원격을 위한 빈 객체를 줬는데 도로 삭제
