### PR TITLE
category를 다시 enum 처리하도록 수정

### DIFF
--- a/src/main/java/io/pp/arcade/domain/admin/controller/FeedbackAdminController.java
+++ b/src/main/java/io/pp/arcade/domain/admin/controller/FeedbackAdminController.java
@@ -15,7 +15,7 @@ public interface FeedbackAdminController {
     void feedbackUpdate(@RequestBody FeedbackUpdateRequestDto updateRequestDto, HttpServletRequest request);
     void feedbackDelete(@PathVariable Integer feedbackId, HttpServletRequest request);
     List<FeedbackDto> feedbackAll(Pageable pageable, HttpServletRequest request);
-    List<FeedbackDto> feedbackFindByCategory(@PathVariable String category, Pageable pageable, HttpServletRequest request);
+    List<FeedbackDto> feedbackFindByCategory(@PathVariable FeedbackType category, Pageable pageable, HttpServletRequest request);
     List<FeedbackDto> feedbackFindByIsSolved(@PathVariable Boolean isSolved, Pageable pageable, HttpServletRequest request);
     List<FeedbackDto> feedbackFindByCategoryAndIsSolved(@RequestBody FeedbackFindRequestDto findRequestDto, Pageable pageable, HttpServletRequest request);
 }

--- a/src/main/java/io/pp/arcade/domain/admin/controller/FeedbackAdminControllerImpl.java
+++ b/src/main/java/io/pp/arcade/domain/admin/controller/FeedbackAdminControllerImpl.java
@@ -5,6 +5,7 @@ import io.pp.arcade.domain.feedback.dto.FeedbackDto;
 import io.pp.arcade.domain.feedback.dto.FeedbackFindRequestDto;
 import io.pp.arcade.domain.admin.dto.update.FeedbackUpdateDto;
 import io.pp.arcade.domain.admin.dto.update.FeedbackUpdateRequestDto;
+import io.pp.arcade.global.type.FeedbackType;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
@@ -46,7 +47,7 @@ public class FeedbackAdminControllerImpl implements FeedbackAdminController {
 
     @Override
     @GetMapping(value = "/feedback/{category}")
-    public List<FeedbackDto> feedbackFindByCategory(String category, Pageable pageable, HttpServletRequest request) {
+    public List<FeedbackDto> feedbackFindByCategory(FeedbackType category, Pageable pageable, HttpServletRequest request) {
         List<FeedbackDto> feedbackDtos = feedbackService.feedbackFindByCategoryByAdmin(category, pageable);
         return feedbackDtos;
     }
@@ -61,7 +62,7 @@ public class FeedbackAdminControllerImpl implements FeedbackAdminController {
     @Override
     @GetMapping(value = "/feedback/categorized")
     public List<FeedbackDto> feedbackFindByCategoryAndIsSolved(FeedbackFindRequestDto findRequestDto, Pageable pageable, HttpServletRequest request) {
-        String category = findRequestDto.getCategory();
+        FeedbackType category = findRequestDto.getCategory();
         Boolean isSolved = findRequestDto.getIsSolved();
         List<FeedbackDto> feedbackDtos = feedbackService.feedbackFindByCategoryAndIsSolvedByAdmin(category, isSolved, pageable);
         return feedbackDtos;

--- a/src/main/java/io/pp/arcade/domain/feedback/Feedback.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/Feedback.java
@@ -27,7 +27,7 @@ public class Feedback extends BaseTimeEntity {
 
     @NotNull
     @Column(name = "category")
-    private String category;
+    private FeedbackType category;
 
     @NotNull
     @Column(name = "content", length = 600)
@@ -39,7 +39,7 @@ public class Feedback extends BaseTimeEntity {
     private Boolean isSolved;
 
     @Builder
-    public Feedback(User user, String category, String content) {
+    public Feedback(User user, FeedbackType category, String content) {
         this.user = user;
         this.category = category;
         this.content = content;

--- a/src/main/java/io/pp/arcade/domain/feedback/FeedbackRepository.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/FeedbackRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Integer> {
-    Page<Feedback> findAllByCategory(String category, Pageable pageable);
+    Page<Feedback> findAllByCategory(FeedbackType category, Pageable pageable);
     Page<Feedback> findAllByIsSolved(Boolean isSolved, Pageable pageable);
-    Page<Feedback> findAllByCategoryAndIsSolved(String category, Boolean isSolved, Pageable pageable);
+    Page<Feedback> findAllByCategoryAndIsSolved(FeedbackType category, Boolean isSolved, Pageable pageable);
 }

--- a/src/main/java/io/pp/arcade/domain/feedback/FeedbackService.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/FeedbackService.java
@@ -65,7 +65,7 @@ public class FeedbackService {
     }
 
     @Transactional
-    public List<FeedbackDto> feedbackFindByCategoryByAdmin(String category, Pageable pageable) {
+    public List<FeedbackDto> feedbackFindByCategoryByAdmin(FeedbackType category, Pageable pageable) {
         Page<Feedback> feedbacks = feedbackRepository.findAllByCategory(category, pageable);
         List<FeedbackDto> feedbackDtos = feedbacks.stream().map(FeedbackDto::from).collect(Collectors.toList());
         return feedbackDtos;
@@ -79,7 +79,7 @@ public class FeedbackService {
     }
 
     @Transactional
-    public List<FeedbackDto> feedbackFindByCategoryAndIsSolvedByAdmin(String category, Boolean isSolved, Pageable pageable) {
+    public List<FeedbackDto> feedbackFindByCategoryAndIsSolvedByAdmin(FeedbackType category, Boolean isSolved, Pageable pageable) {
         Page<Feedback> feedbacks = feedbackRepository.findAllByCategoryAndIsSolved(category, isSolved, pageable);
         List<FeedbackDto> feedbackDtos = feedbacks.stream().map(FeedbackDto::from).collect(Collectors.toList());
         return feedbackDtos;

--- a/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackAddDto.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackAddDto.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @Builder
 public class FeedbackAddDto {
     private Integer userId;
-    private String category;
+    private FeedbackType category;
     private String content;
 
     @Override

--- a/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackDto.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackDto.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class FeedbackDto {
     private Integer id;
     private UserDto user;
-    private String category;
+    private FeedbackType category;
     private String content;
     private Boolean isSolved;
 

--- a/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackFindRequestDto.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackFindRequestDto.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class FeedbackFindRequestDto {
-    private String category;
+    private FeedbackType category;
     private Boolean isSolved;
 }

--- a/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackRequestDto.java
+++ b/src/main/java/io/pp/arcade/domain/feedback/dto/FeedbackRequestDto.java
@@ -1,5 +1,6 @@
 package io.pp.arcade.domain.feedback.dto;
 
+import io.pp.arcade.global.type.FeedbackType;
 import lombok.Getter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.Length;
@@ -7,7 +8,7 @@ import org.hibernate.validator.constraints.Length;
 @Getter
 @ToString
 public class FeedbackRequestDto {
-    private String category;
+    private FeedbackType category;
     @Length(max = 600)
     private String content;
 }

--- a/src/test/java/io/pp/arcade/domain/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/io/pp/arcade/domain/feedback/controller/FeedbackControllerTest.java
@@ -77,7 +77,7 @@ public class FeedbackControllerTest {
 
         alreadySavedFeedback1 = Feedback.builder()
                 .user(user1)
-                .category(FeedbackType.BUG.toString())
+                .category(FeedbackType.BUG)
                 .content("게임 결과 페이지가 안보여요")
                 .build();
 
@@ -85,7 +85,7 @@ public class FeedbackControllerTest {
 
         alreadySavedFeedback2 = Feedback.builder()
                 .user(user2)
-                .category(FeedbackType.GAMERESULT.toString())
+                .category(FeedbackType.GAMERESULT)
                 .content("방금 한 게임 스코어 1:0에서 2:0으로 바꿔주세요!")
                 .build();
 
@@ -93,7 +93,7 @@ public class FeedbackControllerTest {
 
         alreadySavedFeedback3 = Feedback.builder()
                 .user(user3)
-                .category(FeedbackType.CHEERS.toString())
+                .category(FeedbackType.CHEERS)
                 .content("색 조합이 너무 귀여워요. 프론트 짱이다..!")
                 .build();
 
@@ -101,7 +101,7 @@ public class FeedbackControllerTest {
 
         alreadySavedFeedback4 = Feedback.builder()
                 .user(user4)
-                .category(FeedbackType.CHEERS.toString())
+                .category(FeedbackType.CHEERS)
                 .content("서비스 진짜 최곱니다. 이거 하러 클러스터 온다..!")
                 .build();
 
@@ -121,7 +121,7 @@ public class FeedbackControllerTest {
          */
 
         Map<String, String> body = new HashMap<>();
-        body.put("category", FeedbackType.GAMERESULT.toString());
+        body.put("category", FeedbackType.GAMERESULT.getCode());
         body.put("content", "방금 한 게임 스코어 0:2에서 2:0으로 바꿔주세요.");
         mockMvc.perform(post("/pingpong/feedback").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + initiator.tokens[0].getAccessToken())
@@ -130,7 +130,7 @@ public class FeedbackControllerTest {
                 .andDo(document("feedback-save1"));
 
         Map<String, String> body2 = new HashMap<>();
-        body2.put("category", FeedbackType.CHEERS.toString());
+        body2.put("category", FeedbackType.CHEERS.getCode());
         body2.put("content", "프론트 진짜 기가 막히네요!!!!!!!!!! 너무 옙쁘다!");
         mockMvc.perform(post("/pingpong/feedback").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + initiator.tokens[0].getAccessToken())
@@ -139,7 +139,7 @@ public class FeedbackControllerTest {
                 .andDo(document("feedback-save2"));
 
         Map<String, String> body3 = new HashMap<>();
-        body3.put("category", FeedbackType.BUG.toString());
+        body3.put("category", FeedbackType.BUG.getCode());
         body3.put("content", "안들어가져요. 서버 터졌나봐!");
         mockMvc.perform(post("/pingpong/feedback").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + initiator.tokens[0].getAccessToken())
@@ -154,8 +154,9 @@ public class FeedbackControllerTest {
         }
 
         Map<String, String> body4 = new HashMap<>();
-        body4.put("category", FeedbackType.GAMERESULT.toString());
-        body4.put("content", "개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳");
+        body4.put("category", FeedbackType.GAMERESULT.getCode());
+        body4.put("content", "개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳"
+        + "개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳개굳");
         mockMvc.perform(post("/pingpong/feedback").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + initiator.tokens[0].getAccessToken())
                         .content(objectMapper.writeValueAsString(body4)))


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  -
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - 다시 이넘 처리 하기ㅣ..... 왜냐하면 string으로 받을 때, 올바르게 잘 받는지 확인해야하기 때문. 이넘 말고 다른 방법이 있겠지만 우린 이넘을 이미 쓰고 있는걸? 그러면 이넘 다시 써야지!
