### PR TITLE
[fix] 시즌 모드가 대문자로 출력되는 부분 & 시즌 리스트가 빈 리스트로 출력되는 부분 수정 close #426

### DIFF
--- a/src/main/java/io/pp/arcade/v1/domain/season/SeasonController.java
+++ b/src/main/java/io/pp/arcade/v1/domain/season/SeasonController.java
@@ -20,7 +20,7 @@ public class SeasonController {
 
     @GetMapping(value = "/seasonlist")
     public SeasonListResponseDto getRankSeasonList(HttpServletRequest request) {
-        List<SeasonNameDto> seasons = seasonService.findAllSeason();
+        List<SeasonNameDto> seasons = seasonService.findAllRankSeason();
         SeasonDto currentSeason = seasonService.findCurrentSeason();
 
         SeasonListResponseDto responseDto = SeasonListResponseDto.builder().seasonMode(currentSeason.getSeasonMode().getCode()).seasonList(seasons).build();

--- a/src/main/java/io/pp/arcade/v1/domain/season/SeasonRepository.java
+++ b/src/main/java/io/pp/arcade/v1/domain/season/SeasonRepository.java
@@ -14,5 +14,6 @@ public interface SeasonRepository extends JpaRepository <Season, Integer> {
     Optional<Season> findFirstByOrderByIdDesc();
     Optional<Season> findFirstBySeasonModeOrderByIdDesc(Mode seasonMode);
     List<Season> findAllBySeasonMode(Mode mode);
+    List<Season> findAllBySeasonModeOrSeasonMode(Mode mode1, Mode mode2);
     Page<Season> findAllByOrderByIdDesc(Pageable pageable);
 }

--- a/src/main/java/io/pp/arcade/v1/domain/season/SeasonService.java
+++ b/src/main/java/io/pp/arcade/v1/domain/season/SeasonService.java
@@ -83,7 +83,7 @@ public class SeasonService {
 
     @Transactional
     public List<SeasonNameDto> findAllRankSeason() {
-        List<Season> seasons =  seasonRepository.findAllBySeasonMode(Mode.RANK);
+        List<Season> seasons =  seasonRepository.findAllBySeasonModeOrSeasonMode(Mode.RANK, Mode.BOTH);
         List<SeasonNameDto> dtoList = new ArrayList<>();
 
         for (Season season : seasons) {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 시즌 모드의 both가 소문자로 출력되는 부분 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

<img width="236" alt="스크린샷 2022-11-02 오후 5 21 12" src="https://user-images.githubusercontent.com/90084199/199436714-f58be965-b320-4902-9e1f-ac91f7504c5d.png">

- 시즌 조회 시 BOTH(대문자)로 출력되는 부분을 both로 수정하였습니다.
- 랭크 시즌 리스트를 조회시 모드가 both일 경우 조회되지 않는 부분을 수정하였습니다.
