### PR TITLE
[Fix] 게임 결과 조회 오류 수정 #429

### DIFF
--- a/src/main/java/io/pp/arcade/v1/domain/season/SeasonRepository.java
+++ b/src/main/java/io/pp/arcade/v1/domain/season/SeasonRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface SeasonRepository extends JpaRepository <Season, Integer> {
     Optional<Season> findSeasonByStartTimeIsBeforeAndEndTimeIsAfter(LocalDateTime startTime, LocalDateTime endTime);
     Optional<Season> findFirstByOrderByIdDesc();
-    Optional<Season> findFirstBySeasonModeOrderByIdDesc(Mode seasonMode);
+    Optional<Season> findFirstBySeasonModeOrSeasonModeOrderByIdDesc(Mode mode1, Mode mode2);
     List<Season> findAllBySeasonMode(Mode mode);
     List<Season> findAllBySeasonModeOrSeasonMode(Mode mode1, Mode mode2);
     Page<Season> findAllByOrderByIdDesc(Pageable pageable);

--- a/src/main/java/io/pp/arcade/v1/domain/season/SeasonService.java
+++ b/src/main/java/io/pp/arcade/v1/domain/season/SeasonService.java
@@ -57,7 +57,7 @@ public class SeasonService {
 
     @Transactional
     public SeasonDto findLatestRankSeason() {
-        Season season = seasonRepository.findFirstBySeasonModeOrderByIdDesc(Mode.RANK).orElseThrow(() -> new BusinessException("E0001"));
+        Season season = seasonRepository.findFirstBySeasonModeOrSeasonModeOrderByIdDesc(Mode.RANK, Mode.BOTH).orElseThrow(() -> new BusinessException("E0001"));
         return SeasonDto.from(season);
     }
 


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임 결과 조회 오류 수정 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - seasonService.findLatestRankSeason() 메소드에서 모드가 rank인 시즌만 찾다가 에러 발생 -> both인 시즌도 같이 찾도록 수정
