### PR TITLE
[test] 유저별 경기 결과 조회시 없는 유저에 대한 에러코드 반환부분 테스트

### DIFF
--- a/src/main/java/io/pp/arcade/v1/domain/pchange/PChangeService.java
+++ b/src/main/java/io/pp/arcade/v1/domain/pchange/PChangeService.java
@@ -62,7 +62,7 @@ public class PChangeService {
     public PChangeListDto findPChangeByUserIdAfterGameIdAndGameMode(PChangeListFindDto findDto){
         Integer gameId = findDto.getGameId() == null ? Integer.MAX_VALUE : findDto.getGameId();
         Integer mode = findDto.getMode() == null ? null : findDto.getMode().getValue();
-        User user = userRepository.findByIntraId(findDto.getIntraId()).orElseThrow(() -> new BusinessException("SF001"));
+        User user = userRepository.findByIntraId(findDto.getIntraId()).orElseThrow(() -> new BusinessException("UF001"));
 
         List<PChange> pChangePage = pChangeRepository.findPChangesByGameModeAndUser(findDto.getSeason(), mode, user.getIntraId(), gameId, findDto.getCount() + 1);
         Integer count = pChangePage.size();

--- a/src/main/java/io/pp/arcade/v1/global/exception/entity/ExceptionCode.java
+++ b/src/main/java/io/pp/arcade/v1/global/exception/entity/ExceptionCode.java
@@ -27,7 +27,10 @@ public enum ExceptionCode {
     SECURITY_01(HttpStatus.UNAUTHORIZED, "S0001", "권한이 없습니다."),
 
     /* 피드백 공백 에러 */
-    FEEDBACK_RP_BLANK(HttpStatus.BAD_REQUEST, "RP001");
+    FEEDBACK_RP_BLANK(HttpStatus.BAD_REQUEST, "RP001"),
+
+    /*유저별 전적 페이지 에러 - 유저 찾을 수 없음*/
+    USER_FALSE(HttpStatus.BAD_REQUEST, "UF001");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/io/pp/arcade/domain/game/controller/GameControllerTest.java
+++ b/src/test/java/io/pp/arcade/domain/game/controller/GameControllerTest.java
@@ -510,6 +510,7 @@ class GameControllerTest {
                         .params(params2)
                         .header("Authorization", "Bearer " + initiator.tokens[0].getAccessToken()))
                 .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("UF001"))
                 .andDo(document("game-find-results-4xxError-cause-couldn't-find-intraId"));
 
         /*


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저별 경기 결과 조회시 없는 유저에 대한 에러코드 반환부분 테스트
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 유저별 경기 결과 조회시 없는 유저에 대한 에러코드 반환부분 테스트코드 작성
  - /pingpong/users/{intraId}/games 에서 intraId 없을 시 에러코드 UF001 반환
