### PR TITLE
[fix] redis 경험치 증가 ttl 갱신하는 코드 추가

### DIFF
--- a/src/main/java/io/pp/arcade/v1/domain/game/Manager/GameManager.java
+++ b/src/main/java/io/pp/arcade/v1/domain/game/Manager/GameManager.java
@@ -112,6 +112,7 @@ public class GameManager {
                 redisTemplate.opsForValue().set(Key.GAME_PER_DAY + slotTeamUser.getUser().getIntraId(), 1, 3, TimeUnit.HOURS);
             } else {
                 redisTemplate.opsForValue().increment(Key.GAME_PER_DAY + slotTeamUser.getUser().getIntraId());
+                redisTemplate.opsForValue().getAndExpire(Key.GAME_PER_DAY + slotTeamUser.getUser().getIntraId(), 3, TimeUnit.HOURS);
             }
             Integer expChange = ExpLevelCalculator.getExpPerGame() + ExpLevelCalculator.getExpBonus() * gamePerDay;
 


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - redis 경험치 증가 ttl 갱신하는 코드 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - redis 경험치 증가 ttl 갱신하는 코드 추가
  - 현재 : 첫경기 후 3시간동안만 적용
  - 변경 : 경기 할때마다 3시간으로 갱신
