### PR TITLE
[fix] 시즌별 랭크 정보 레디스에서 가져오도록 수정 close #512

### DIFF
--- a/src/main/java/io/pp/arcade/v1/domain/game/Manager/Factory/GameRankFactory.java
+++ b/src/main/java/io/pp/arcade/v1/domain/game/Manager/Factory/GameRankFactory.java
@@ -35,7 +35,7 @@ public class GameRankFactory implements GameFactory{
 
         RankUserDto rankUserDto = rankRedisService.findRankById(RankRedisFindDto.builder()
                 .gameType(gameDto.getSlot().getType())
-                .userDto(slotTeamUser.getUser()).build());
+                .user(slotTeamUser.getUser()).build());
         PChangeDto pChangeDto = gameDto.getStatus() == StatusType.END ?
                 pChangeService.findPChangeByUserAndGame(PChangeFindDto.builder().game(gameDto).user(slotTeamUser.getUser()).build())
                 : PChangeDto.builder().user(slotTeamUser.getUser()).game(gameDto).pppChange(0).pppResult(0).expChange(0).expResult(0).build();

--- a/src/main/java/io/pp/arcade/v1/domain/rank/dto/RankRedisFindDto.java
+++ b/src/main/java/io/pp/arcade/v1/domain/rank/dto/RankRedisFindDto.java
@@ -1,5 +1,6 @@
 package io.pp.arcade.v1.domain.rank.dto;
 
+import io.pp.arcade.v1.domain.season.dto.SeasonDto;
 import io.pp.arcade.v1.domain.user.dto.UserDto;
 import io.pp.arcade.v1.global.type.GameType;
 import lombok.Builder;
@@ -8,14 +9,16 @@ import lombok.Getter;
 @Builder
 @Getter
 public class RankRedisFindDto {
-    private UserDto userDto;
+    private UserDto user;
     private GameType gameType;
+    private SeasonDto season;
 
     @Override
     public String toString() {
         return "RankFindDto{" +
-                "intraId='" + userDto.getIntraId() + '\'' +
+                "user='" + user +
                 ", gameType=" + gameType +
+                ", season=" + season +
                 '}';
     }
 }

--- a/src/main/java/io/pp/arcade/v1/domain/rank/service/RankRedisService.java
+++ b/src/main/java/io/pp/arcade/v1/domain/rank/service/RankRedisService.java
@@ -3,6 +3,7 @@ package io.pp.arcade.v1.domain.rank.service;
 import io.pp.arcade.v1.domain.rank.RankRedisRepository;
 import io.pp.arcade.v1.domain.rank.RedisKeyManager;
 import io.pp.arcade.v1.domain.rank.dto.*;
+import io.pp.arcade.v1.domain.season.Season;
 import io.pp.arcade.v1.domain.season.SeasonService;
 import io.pp.arcade.v1.domain.season.dto.SeasonDto;
 import io.pp.arcade.v1.domain.season.dto.SeasonNameDto;
@@ -174,11 +175,10 @@ public class RankRedisService {
         return rankUserDtos;
     }
 
-    /* 현재 시즌만 조회 가능 */
     public RankUserDto findRankById(RankRedisFindDto findDto) {
-        Integer userId = findDto.getUserDto().getId();
-        SeasonDto curSeasonDto = seasonService.findLatestRankSeason();
-        RankKeyGetDto keyGetDto = RankKeyGetDto.builder().seasonId(curSeasonDto.getId()).seasonName(curSeasonDto.getSeasonName()).build();
+        Integer userId = findDto.getUser().getId();
+        SeasonDto season = findDto.getSeason() != null ? findDto.getSeason() : seasonService.findLatestRankSeason();
+        RankKeyGetDto keyGetDto = RankKeyGetDto.builder().seasonId(season.getId()).seasonName(season.getSeasonName()).build();
         String curRankKey = redisKeyManager.getRankKeyBySeason(keyGetDto);
 
         RankRedis rank = rankRedisRepository.findRank(curRankKey, userId);

--- a/src/main/java/io/pp/arcade/v1/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/io/pp/arcade/v1/domain/user/controller/UserControllerImpl.java
@@ -115,11 +115,11 @@ public class UserControllerImpl implements UserController {
         if (season == 0) {
             season = seasonService.findLatestRankSeason().getId();
         }
-
-        if (season.equals(seasonService.findLatestRankSeason().getId()))  {
-            rankDto = rankRedisService.findRankById(RankRedisFindDto.builder().userDto(targetUser).gameType(GameType.SINGLE).build());
+        SeasonDto seasonDto = seasonService.findSeasonById(season);
+        if (seasonDto.getId().equals(seasonService.findLatestRankSeason().getId()))  {
+            rankDto = rankRedisService.findRankById(RankRedisFindDto.builder().user(targetUser).gameType(GameType.SINGLE).build());
         } else {
-            rankDto = getRankUserDtoFromSeasonAndTargetUser(season, targetUser);
+            rankDto = rankRedisService.findRankById(RankRedisFindDto.builder().user(targetUser).gameType(GameType.SINGLE).season(seasonDto).build());
         }
         UserRankResponseDto responseDto = UserRankResponseDto.builder()
                 .rank(rankDto.getRank())


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 프로필 페이지 시즌별 랭크 정보 레디스에서 가져오도록 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 프로필 페이지 시즌별 랭크 정보 레디스에서 가져오도록 수정
  - RankRedisFindDto에 season 추가
  - RankRedisService.findRankById 메소드 시즌별 랭크 정보 찾을 수 있도록 수정
