### PR TITLE
[Fix] seasonId null and mysql to redis #523 #524

### DIFF
--- a/src/main/java/io/pp/arcade/v1/domain/game/v1/GameControllerImplV1.java
+++ b/src/main/java/io/pp/arcade/v1/domain/game/v1/GameControllerImplV1.java
@@ -182,7 +182,7 @@ public class GameControllerImplV1 {
     private GameFindDto getGameFindDto(GameResultPageRequestDto requestDto, Mode mode) {
         /* 시즌 조회 */
         Integer seasonId = requestDto.getSeason();
-        if (requestDto.getSeason() == null) {
+        if (seasonId != null && seasonId == 0) {
             SeasonDto currentSeason = seasonService.findLatestRankSeason();
             if (currentSeason != null) {
                 seasonId = seasonService.findLatestRankSeason().getId();

--- a/src/main/java/io/pp/arcade/v1/domain/rank/entity/RankRedis.java
+++ b/src/main/java/io/pp/arcade/v1/domain/rank/entity/RankRedis.java
@@ -75,7 +75,7 @@ public class RankRedis implements Serializable {
         Integer losses = rankDto.getLosses();
         Integer wins = rankDto.getWins();
         RankRedis rankRedis = RankRedis.builder()
-                .id(rankDto.getId())
+                .id(rankDto.getUser().getId())
                 .intraId(rankDto.getUser().getIntraId())
                 .ppp(rankDto.getPpp())
                 .gameType(gameType)


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 자잘한 에러 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 경기 결과 조회시 season이 null인 경우 전체 시즌 대상으로 조회하도록 수정
  - 새로운 시즌 추가한 뒤 mysql -> redis로 백업 시 인덱스가 1부터 시작하도록 수정
